### PR TITLE
AVX-10308: add readme, modify output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In order to run `aviatrix_controller_init.py` python script, dependencies listed
 **build_controller.tf**
 ```
 module "aviatrix_controller_build" {
-  source           = "./aviatrix-controller-build/simple"
+  source           = "github.com/AviatrixSystems/terraform-module-oci.git//aviatrix-controller-build/simple"
   tenancy_ocid     = "<< tenancy ocid >>"
   compartment_ocid = "<< compartment ocid >>"
   user_ocid        = "<< user ocid >>"
@@ -54,22 +54,6 @@ output "aviatrix_controller_private_ip" {
 
 output "aviatrix_controller_url" {
   value = module.aviatrix_controller_build.aviatrix_controller_url
-}
-
-output "aviatrix_controller_tenancy_id" {
-  value = module.aviatrix_controller_build.aviatrix_controller_tenancy_id
-}
-
-output "aviatrix_controller_compartment_id" {
-  value = module.aviatrix_controller_build.aviatrix_controller_compartment_id
-}
-
-output "aviatrix_controller_user_id" {
-  value = module.aviatrix_controller_build.aviatrix_controller_user_id
-}
-
-output "aviatrix_controller_api_key_path" {
-  value = module.aviatrix_controller_build.aviatrix_controller_api_key_path
 }
 ```
 *Execute*
@@ -84,18 +68,19 @@ cd ..
 **controller_init.tf**
 ```
 module "aviatrix_controller_initialize" {
-  source                        = "./aviatrix-controller-initialize"
+  source                        = "github.com/AviatrixSystems/terraform-module-oci.git//aviatrix-controller-initialize"
   avx_controller_public_ip      = "<< public ip address of the Aviatrix Controller >>"
   avx_controller_private_ip     = "<< private ip address of the Aviatrix Controller >>"
-  avx_controller_admin_email    = "<< your admin email address for the Aviatrix Controller >>"
-  avx_controller_admin_password = "<< your admin password for the Aviatrix Controller >>"
-  oci_tenancy_id                = "<< OCI tenancy id >>"
-  oci_user_id                   = "<< OCI user id >>"
-  oci_compartment_id            = "<< OCI compartment id >>"
-  oci_api_key_path              = "<< OCI SSH private key path >>"
-  account_email                 = "<< your email address for your access account >>"
-  access_account_name           = "<< your account name mapping to your Azure account >>"
-  aviatrix_customer_id          = "<< your customer license id >>"
+  avx_controller_admin_email    = "<< admin email address for the Aviatrix Controller >>"
+  avx_controller_admin_password = "<< admin password for the Aviatrix Controller >>"
+  oci_tenancy_id                = "<< tenancy ocid >>"
+  oci_user_id                   = "<< user ocid >>"
+  oci_compartment_id            = "<< compartment ocid >>"
+  oci_api_key_path              = "<< private key path >>"
+  account_email                 = "<< email address for the access account >>"
+  access_account_name           = "<< account name mapping to the Azure account >>"
+  aviatrix_customer_id          = "<< customer license id >>"
+  controller_version            = "<< desired controller version. defaults to 'latest' >>"
 }
 ```
 *Execute*
@@ -110,7 +95,7 @@ cd ..
 The controller buildup and initialization can be done using a single terraform file.
 ```
 module "aviatrix_controller_build" {
-  source           = "./aviatrix-controller-build/simple"
+  source           = "github.com/AviatrixSystems/terraform-module-oci.git//aviatrix-controller-build/simple"
   tenancy_ocid     = "<< tenancy ocid >>"
   compartment_ocid = "<< compartment ocid >>"
   user_ocid        = "<< user ocid >>"
@@ -133,35 +118,20 @@ output "aviatrix_controller_url" {
   value = module.aviatrix_controller_build.aviatrix_controller_url
 }
 
-output "aviatrix_controller_tenancy_id" {
-  value = module.aviatrix_controller_build.aviatrix_controller_tenancy_id
-}
-
-output "aviatrix_controller_compartment_id" {
-  value = module.aviatrix_controller_build.aviatrix_controller_compartment_id
-}
-
-output "aviatrix_controller_user_id" {
-  value = module.aviatrix_controller_build.aviatrix_controller_user_id
-}
-
-output "aviatrix_controller_api_key_path" {
-  value = module.aviatrix_controller_build.aviatrix_controller_api_key_path
-}
-
 module "aviatrix_controller_initialize" {
-  source                        = "./aviatrix-controller-initialize"
+  source                        = "github.com/AviatrixSystems/terraform-module-oci.git//aviatrix-controller-initialize"
   avx_controller_public_ip      = module.aviatrix_controller_build.aviatrix_controller_public_ip
   avx_controller_private_ip     = module.aviatrix_controller_build.aviatrix_controller_private_ip
-  avx_controller_admin_email    = "<< your admin email address for the Aviatrix Controller >>"
-  avx_controller_admin_password = "<< your admin password for the Aviatrix Controller >>"
-  oci_tenancy_id                = module.aviatrix_controller_build.aviatrix_controller_tenancy_id
-  oci_user_id                   = module.aviatrix_controller_build.aviatrix_controller_user_id
-  oci_compartment_id            = module.aviatrix_controller_build.aviatrix_controller_compartment_id
-  oci_api_key_path              = module.aviatrix_controller_build.aviatrix_controller_api_key_path
-  account_email                 = "<< your email address for your access account >>"
-  access_account_name           = "<< your account name mapping to your Azure account >>"
-  aviatrix_customer_id          = "<< your customer license id >>"
+  avx_controller_admin_email    = "<< admin email address for the Aviatrix Controller >>"
+  avx_controller_admin_password = "<< admin password for the Aviatrix Controller >>"
+  oci_tenancy_id                = "<< tenancy ocid >>"
+  oci_user_id                   = "<< user ocid >>"
+  oci_compartment_id            = "<< compartment ocid >>"
+  oci_api_key_path              = "<< private key path >>"
+  account_email                 = "<< email address for the access account >>"
+  access_account_name           = "<< account name mapping to the Azure account >>"
+  aviatrix_customer_id          = "<< customer license id >>"
+  controller_version            = "<< desired controller version. defaults to 'latest' >>"
 }
 ```
 *Execute*

--- a/aviatrix-controller-build/README.md
+++ b/aviatrix-controller-build/README.md
@@ -1,0 +1,124 @@
+## Aviatrix - Terraform Modules OCI - Build Aviatrix Controller
+
+### Description
+
+This Terraform module creates an Aviatrix Controller and related components in OCI.
+
+### Usage:
+
+To create an Aviatrix Controller:
+
+```
+module "aviatrix_controller_build" {
+  source           = "github.com/AviatrixSystems/terraform-module-oci.git//aviatrix-controller-build/simple"
+  tenancy_ocid     = "<< tenancy ocid >>"
+  compartment_ocid = "<< compartment ocid >>"
+  user_ocid        = "<< user ocid >>"
+  fingerprint      = "<< fingerprint >>"
+  ssh_public_key   = "<< ssh public key path >>"
+  private_key_path = "<< private key path >>"
+  license_model    = "<< BYOL or PAID >>"
+  region           = "<< controller region >>"
+}
+```
+
+### Variables
+
+- **tenancy_ocid**
+
+  Tenancy OCID.
+
+- **compartment_ocid**
+
+  Compartment OCID.
+
+- **user_ocid**
+
+  User OCID.
+
+- **fingerprint** 
+
+  Fingerprint of the public key.
+
+- **ssh_public_key**
+
+  Public key file path.
+
+- **private_key_path**
+
+  Private key file path.
+
+- **region**
+
+  Region.
+
+- **license_model**
+
+  Marketplace license model: "BYOL" or "PAID"
+
+- **product_version**
+
+  Aviatrix Controller Version available in the Marketplace. Default value: "5.0.1".
+
+- **availability_domain**
+
+  OCI Availability Domains: 1,2,3 (subject to region availability). Default value: 1.
+
+- **vm_display_name**
+
+  VM display name. Default value: "controller".
+
+- **vm_compute_shape**
+
+  VM compute shape. Default value: "VM.Standard2.2".
+
+- **vcn_display_name**
+
+  VCN display name. Default value: "aviatrix-vcn".
+
+- **vcn_dns_label**
+
+  VCN DNS label. Default value: "aviatrix".
+
+- **vcn_cidr_block**
+
+  VCN CIDR block. Default value: "10.0.0.0/16".
+
+- **routetable_display_name**
+
+  Route table display name. Default value: "controller-route-table".
+
+- **subnet_display_name**
+
+  Subnet display name. Default value: "controller-subnet".
+
+- **subnet_cidr_block**
+
+  Subnet CIDR block. Default value: "10.0.0.0/24".
+
+- **subnet_dns_label**
+
+  Subnet DNS label. Default value: "management".
+
+- **nsg_display_name**
+
+  Network security group display name. Default value: "controller-sec-group".
+
+- **nsg_whitelist_ip**
+
+  Whitelisted CIDR block for ingress communication. Default value: "0.0.0.0/0".
+
+### Outputs
+
+- **aviatrix_controller_public_ip**
+
+  Controller public IP.
+
+- **aviatrix_controller_private_ip**
+
+  Controller private IP.
+
+- **aviatrix_controller_url**
+
+  Controller URL.
+  

--- a/aviatrix-controller-build/simple/outputs.tf
+++ b/aviatrix-controller-build/simple/outputs.tf
@@ -23,19 +23,3 @@ output "aviatrix_controller_private_ip" {
 output "aviatrix_controller_url" {
   value = "https://${oci_core_instance.simple-vm.public_ip}"
 }
-
-output "aviatrix_controller_tenancy_id" {
-  value = var.tenancy_ocid
-}
-
-output "aviatrix_controller_compartment_id" {
-  value = var.compartment_ocid
-}
-
-output "aviatrix_controller_user_id" {
-  value = var.user_ocid
-}
-
-output "aviatrix_controller_api_key_path" {
-  value = var.private_key_path
-}

--- a/aviatrix-controller-initialize/README.md
+++ b/aviatrix-controller-initialize/README.md
@@ -1,0 +1,75 @@
+## Aviatrix - Terraform Modules OCI - Initialize Aviatrix Controller 
+
+### Description
+
+This Terraform module initializes a newly created Aviatrix Controller.
+
+### Usage
+
+``` terraform
+module "aviatrix_controller_initialize" {
+  source                        = "github.com/AviatrixSystems/terraform-module-oci.git//aviatrix-controller-initialize"
+  avx_controller_public_ip      = "<< public ip address of the Aviatrix Controller >>"
+  avx_controller_private_ip     = "<< private ip address of the Aviatrix Controller >>"
+  avx_controller_admin_email    = "<< admin email address for the Aviatrix Controller >>"
+  avx_controller_admin_password = "<< admin password for the Aviatrix Controller >>"
+  oci_tenancy_id                = "<< tenancy ocid >>"
+  oci_user_id                   = "<< user ocid >>"
+  oci_compartment_id            = "<< compartment ocid >>"
+  oci_api_key_path              = "<< private key path >>"
+  account_email                 = "<< email address for the access account >>"
+  access_account_name           = "<< account name mapping to the Azure account >>"
+  aviatrix_customer_id          = "<< customer license id >>"
+  controller_version            = "<< desired controller version. defaults to 'latest' >>"
+}
+```
+
+### Variables
+
+- **avx_controller_public_ip**
+
+  Aviatrix controller public IP address.
+
+- **avx_controller_private_ip**
+
+  Aviatrix controller private IP address.
+
+- **avx_controller_admin_email**
+
+  Aviatrix controller admin email address.
+
+- **avx_controller_admin_password**
+
+  Aviatrix controller admin password.
+
+- **oci_tenancy_id**
+
+  Tenancy OCID.
+
+- **oci_user_id**
+
+  User OCID.
+
+- **oci_compartment_id**
+
+  Compartment OCID.
+
+- **oci_api_key_path**
+
+  API key file path.
+
+- **account_email**
+
+  Aviatrix controller access account email.
+
+- **access_account_name**
+
+  Aviatrix controller access account name.
+
+- **aviatrix_customer_id**
+
+  Aviatrix customer license id".
+
+- **controller_version**
+
+  Aviatrix Controller version. Default value: "latest".

--- a/aviatrix-controller-initialize/aviatrix_controller_init.py
+++ b/aviatrix-controller-initialize/aviatrix_controller_init.py
@@ -852,6 +852,7 @@ if __name__ == "__main__":
     account_email = sys.argv[9]
     access_account_name = sys.argv[10]
     aviatrix_customer_id = sys.argv[11]
+    controller_version = sys.argv[12]
 
     event = {
         "hostname": hostname,
@@ -860,7 +861,7 @@ if __name__ == "__main__":
         "aviatrix_api_route": "api",
         "admin_email": admin_email,
         "new_admin_password": new_admin_password,
-        "controller_init_version": "latest",
+        "controller_init_version": controller_version,
         "oci_tenancy_id": oci_tenancy_id,
         "oci_user_id": oci_user_id,
         "oci_compartment_id": oci_compartment_id,

--- a/aviatrix-controller-initialize/main.tf
+++ b/aviatrix-controller-initialize/main.tf
@@ -16,11 +16,11 @@ locals {
   option = format("%s/aviatrix_controller_init.py",
     path.module
   )
-  argument = format("'%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s'",
+  argument = format("'%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s'",
     var.avx_controller_public_ip, var.avx_controller_private_ip, var.avx_controller_admin_email,
     var.avx_controller_admin_password, var.oci_tenancy_id, var.oci_user_id,
     var.oci_compartment_id, var.oci_api_key_path, var.account_email, var.access_account_name,
-    var.aviatrix_customer_id
+    var.aviatrix_customer_id, var.controller_version
   )
 }
 resource "null_resource" "run_script" {

--- a/aviatrix-controller-initialize/variables.tf
+++ b/aviatrix-controller-initialize/variables.tf
@@ -66,3 +66,9 @@ variable "aviatrix_customer_id" {
   type        = string
   description = "aviatrix customer license id"
 }
+
+variable "controller_version" {
+  type        = string
+  description = "Aviatrix Controller version"
+  default     = "latest"
+}


### PR DESCRIPTION
According to Anthony's feedback, here are the changes:

- added `controller_version`
- added README in both build and initialize modules
- left `wait_until_controller_api_server_is_ready` as is for now, since it's used in all modules.
- removed some sensitive outputs in the build module