### PR TITLE
AVX-19859: Update for 6.3.0 and 6.3.1

### DIFF
--- a/aviatrix-controller-build/README.md
+++ b/aviatrix-controller-build/README.md
@@ -63,7 +63,7 @@ module "aviatrix_controller_build" {
 
 - **product_version**
 
-  Aviatrix Controller Version available in the Marketplace. Default value: "5.0.1".
+  Aviatrix Controller Version available in the Marketplace. Default value: "6.3.0".
 
 - **availability_domain**
 

--- a/aviatrix-controller-build/marketplace/byol/build_mkpl_byol.sh
+++ b/aviatrix-controller-build/marketplace/byol/build_mkpl_byol.sh
@@ -19,7 +19,7 @@
 # Adds: mkpl-schema.yaml, image_subscription.tf
 # Output: $out_file
 
-out_file="aviatrix-byol-5.0.1.zip"
+out_file="aviatrix-byol-6.3.1.zip"
 
 echo "cleanup"
 rm -rf ./tmp_package

--- a/aviatrix-controller-build/marketplace/byol/marketplace.yaml
+++ b/aviatrix-controller-build/marketplace/byol/marketplace.yaml
@@ -17,7 +17,7 @@ title: Aviatrix Secure Networking Platform - BYOL
 # Sub Title shown in Application Information tab.
 description: Multi-Cloud Cross-Region Aviatrix Controller
 schemaVersion: 1.1.0
-version: "20190304"
+version: "20220307"
 
 # URL of Logo Icon used on Application Information tab. Logo must be 130x130 pixels.
 # (Optional)
@@ -41,7 +41,8 @@ variableGroups:
       - region 
       - mp_listing_id
       - mp_listing_resource_id
-      - mp_listing_resource_version      
+      - mp_listing_resource_version
+      - ${marketplace_source_images}   
 
   - title: "Compute Configuration"
     variables:

--- a/aviatrix-controller-build/marketplace/byol/oci_images.tf
+++ b/aviatrix-controller-build/marketplace/byol/oci_images.tf
@@ -1,0 +1,14 @@
+variable "marketplace_source_images" {
+  type = map(object({
+    ocid = string
+    is_pricing_associated = bool
+    compatible_shapes = set(string)
+  }))
+  default = {
+    main_mktpl_image = {
+      ocid = "ocid1.image.oc1..aaaaaaaawyzirrayoeo5ivzkf57texkiu44ytnfifkmzry2xm5uu4otfk7cq"
+      is_pricing_associated = false
+      compatible_shapes = []
+    }
+  }
+}

--- a/aviatrix-controller-build/marketplace/byol/variables.tf
+++ b/aviatrix-controller-build/marketplace/byol/variables.tf
@@ -28,11 +28,11 @@ variable "mp_listing_id" {
 }
 
 variable "mp_listing_resource_id" {
-  default = "ocid1.image.oc1..aaaaaaaaltulqugc5ygggevy3ig7mv2io75azdareylypx23ezhvonqgrcrq"
+  default = "ocid1.image.oc1..aaaaaaaawyzirrayoeo5ivzkf57texkiu44ytnfifkmzry2xm5uu4otfk7cq"
 }
 
 variable "mp_listing_resource_version" {
-  default = "5.0.1"
+  default = "6.3.1"
 }
 
 ############################

--- a/aviatrix-controller-build/marketplace/paid/build_mkpl_paid.sh
+++ b/aviatrix-controller-build/marketplace/paid/build_mkpl_paid.sh
@@ -19,7 +19,7 @@
 # Adds: mkpl-schema.yaml, image_subscription.tf
 # Output: $out_file
 
-out_file="aviatrix-paid-5.0.1.zip"
+out_file="aviatrix-paid-6.3.0.zip"
 
 echo "cleanup"
 rm -rf ./tmp_package

--- a/aviatrix-controller-build/marketplace/paid/marketplace.yaml
+++ b/aviatrix-controller-build/marketplace/paid/marketplace.yaml
@@ -17,7 +17,7 @@ title: Aviatrix Secure Networking Platform
 # Sub Title shown in Application Information tab.
 description: Multi-Cloud Cross-Region Aviatrix Controller
 schemaVersion: 1.1.0
-version: "20190304"
+version: "20220210"
 
 # URL of Logo Icon used on Application Information tab. Logo must be 130x130 pixels.
 # (Optional)
@@ -41,7 +41,8 @@ variableGroups:
       - region 
       - mp_listing_id
       - mp_listing_resource_id
-      - mp_listing_resource_version      
+      - mp_listing_resource_version
+      - ${marketplace_source_images}     
 
   - title: "Compute Configuration"
     variables:

--- a/aviatrix-controller-build/marketplace/paid/oci_images.tf
+++ b/aviatrix-controller-build/marketplace/paid/oci_images.tf
@@ -1,0 +1,14 @@
+variable "marketplace_source_images" {
+  type = map(object({
+    ocid = string
+    is_pricing_associated = bool
+    compatible_shapes = set(string)
+  }))
+  default = {
+    main_mktpl_image = {
+      ocid = "ocid1.image.oc1..aaaaaaaams7arhiyikfhpvo2kj35ky76csllxdnzijqw6ves4a5saaj63mva"
+      is_pricing_associated = true
+      compatible_shapes = []
+    }
+  }
+}

--- a/aviatrix-controller-build/marketplace/paid/variables.tf
+++ b/aviatrix-controller-build/marketplace/paid/variables.tf
@@ -28,11 +28,11 @@ variable "mp_listing_id" {
 }
 
 variable "mp_listing_resource_id" {
-  default = "ocid1.image.oc1..aaaaaaaa3zkysxdvsyb76plwj4tw54iiibozlfq3quwgiveeaqdscwmtwgoa"
+  default = "ocid1.image.oc1..aaaaaaaams7arhiyikfhpvo2kj35ky76csllxdnzijqw6ves4a5saaj63mva"
 }
 
 variable "mp_listing_resource_version" {
-  default = "5.0.1"
+  default = "6.3.0"
 }
 
 ############################

--- a/aviatrix-controller-build/simple/variables.tf
+++ b/aviatrix-controller-build/simple/variables.tf
@@ -46,7 +46,7 @@ variable "license_model" {
 }
 
 variable "product_version" {
-  default     = "5.0.1"
+  default     = "6.3.0"
   description = "Aviatrix Controller Version available in the Marketplace"
 }
 

--- a/aviatrix-controller-build/terraform-modules/marketplace/listings/variables.tf
+++ b/aviatrix-controller-build/terraform-modules/marketplace/listings/variables.tf
@@ -40,7 +40,7 @@ variable "mp_paid_versions" {
   type = map(string)
 
   default = {
-    "5.0.1" = "5.0.1"
+    "6.3.0" = "6.3.0"
   }
 }
 
@@ -48,7 +48,7 @@ variable "mp_byol_versions" {
   type = map(string)
 
   default = {
-    "5.0.1" = "5.0.1"
+    "6.3.0" = "6.3.1"
   }
 }
 
@@ -58,7 +58,7 @@ variable "mp_paid_listing_resource_id" {
   type = map(string)
 
   default = {
-    "5.0.1" = "ocid1.image.oc1..aaaaaaaa3zkysxdvsyb76plwj4tw54iiibozlfq3quwgiveeaqdscwmtwgoa"
+    "6.3.0" = "ocid1.image.oc1..aaaaaaaams7arhiyikfhpvo2kj35ky76csllxdnzijqw6ves4a5saaj63mva"
   }
 }
 
@@ -66,7 +66,7 @@ variable "mp_byol_listing_resource_id" {
   type = map(string)
 
   default = {
-    "5.0.1" = "ocid1.image.oc1..aaaaaaaaltulqugc5ygggevy3ig7mv2io75azdareylypx23ezhvonqgrcrq"
+    "6.3.1" = "ocid1.image.oc1..aaaaaaaawyzirrayoeo5ivzkf57texkiu44ytnfifkmzry2xm5uu4otfk7cq"
   }
 }
 


### PR DESCRIPTION
Still testing this, but this upgrades our terraform scripts to reference the new compute images. 

- BYOL -- 6.3.1 -- ocid1.image.oc1..aaaaaaaawyzirrayoeo5ivzkf57texkiu44ytnfifkmzry2xm5uu4otfk7cq
- PAYG -- 6.3.0 -- ocid1.image.oc1..aaaaaaaams7arhiyikfhpvo2kj35ky76csllxdnzijqw6ves4a5saaj63mva